### PR TITLE
ansible-later

### DIFF
--- a/.later.yml
+++ b/.later.yml
@@ -1,0 +1,18 @@
+---
+ansible:
+  # Add the name of used custom Ansible modules. Otherwise ansible-later
+  # can't detect unknown modules and will through an error.
+  # Modules which are bundled with the role and placed in a './library'
+  # directory will be auto-detected and don't need to be added to this list.
+  custom_modules: []
+
+  # List of yamllint compatible literal bools (ANSIBLE0014)
+  literal-bools:
+    - "true"
+    - "false"
+rules:
+  exclude_files:
+    - molecule/
+    - files/conda-envs/
+    - requirements.txt
+...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # defaults file for base_conda
-
+# Standards: 0.2
 lin_installer: 'Miniconda3-py38_4.9.2-Linux-x86_64.sh'
 lin_conda_url: 'https://repo.anaconda.com/miniconda/{{ lin_installer }}'
 lin_conda_sha256: 'sha256:1314b90489f154602fd794accfc90446111514a5a72fe1f71ab83e07de9504a7'
+...

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,0 @@
----
-# handlers file for base_conda

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,10 @@
 ---
+# Standards: 0.2
 dependencies: []
 
 galaxy_info:
+  role_name: base_conda
+  namespace: dockpack
   author: bbaassssiiee
   description: |
     Miniconda is the minimal version of Anaconda, a cross-platform
@@ -9,13 +12,30 @@ galaxy_info:
   license: MIT
   min_ansible_version: 2.7.0
   platforms:
+    - name: Ubuntu
+      versions:
+        - focal
+    - name: Debian
+      versions:
+        - buster
+    - name: EL
+      versions:
+        - 7
+        - 8
+    - name: Fedora
+      versions:
+        - all
     - name: Windows
       versions:
         - all
         - 2016
+    - name: macOS
+      versions:
+        - all
   galaxy_tags:
     - anaconda
     - windows
+    - macos
     - conda
     - python
     - virtualenv

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,8 @@
 ---
-
+# Standards: 0.2
 
 # Mac
-- name: install miniconda on macos
+- name: Install miniconda on macos
   become: false
   command: /usr/local/bin/brew install miniconda
   when:
@@ -10,12 +10,12 @@
 
 # Debian Linux
 - block:
-    - name: install conda gpg key
+    - name: Install conda apt gpg key
       apt_key:
         state: present
         url: 'https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc'
 
-    - name: install Conda Debian repo
+    - name: Install Conda Debian repo
       apt_repository:
         repo: 'deb https://repo.anaconda.com/pkgs/misc/debrepo/conda stable main'
         filename: conda.list
@@ -24,12 +24,12 @@
 
 # RedHat Linux
 - block:
-    - name: install conda gpg key
+    - name: Install conda rpm gpg key
       rpm_key:
         state: present
         key: 'https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc'
 
-    - name: install Conda Yum repo
+    - name: Install Conda Yum repo
       copy:
         src: conda.repo
         dest: /etc/yum.repos.d
@@ -40,14 +40,14 @@
     - ansible_os_family == 'RedHat'
 
 # Linux
-- name: install miniconda package
+- name: Install miniconda package
   package:
     name: conda
     state: present
   when: ansible_os_family in ['RedHat', 'Debian']
 
 - block:
-    - name: install package dependencies for miniconda installation
+    - name: Install package dependencies for miniconda installation
       package:
         name: bzip2
         state: present
@@ -56,7 +56,7 @@
       retries: 3
       delay: 2
 
-    - name: download miniconda installer
+    - name: Download miniconda installer
       get_url:
         url: "{{ miniconda_installer_url }}"
         checksum: "{{ miniconda_checksum }}"
@@ -67,26 +67,26 @@
       until: miniconda_download is succeeded
       retries: 3
 
-    - name: install miniconda
+    - name: Install miniconda
       command: "/tmp/{{ miniconda_installer_sh }} -b -p {{ miniconda_dir }}"
       args:
         creates: "{{ miniconda_bindir }}"
 
-    - name: delete miniconda installer
+    - name: Delete miniconda installer
       file:
         path: "/tmp/{{ miniconda_installer_sh }}"
         state: absent
   when: ansible_os_family not in ['RedHat', 'Debian', 'Darwin', 'Windows']
 
 - block:
-    - name: link /etc/profile.d/conda.sh
+    - name: Link /etc/profile.d/conda.sh
       file:
         src: "{{ miniconda_dir }}/etc/profile.d/conda.sh"
         dest: /etc/profile.d/conda.sh
         state: link
         mode: 0777
 
-    - name: link /etc/profile.d/conda.csh
+    - name: Link /etc/profile.d/conda.csh
       file:
         src: "{{ miniconda_dir }}/etc/profile.d/conda.csh"
         dest: /etc/profile.d/conda.csh
@@ -94,7 +94,7 @@
         mode: 0777
   when: ansible_os_family == 'RedHat'
 
-- name: source conda.sh in /etc/bash.bashrc
+- name: Source conda.sh in /etc/bash.bashrc
   blockinfile:
     path: "/etc/bash.bashrc"
     state: present
@@ -107,12 +107,12 @@
 # Windows
 - block:
 
-    - name: ensure download directory exists on windows
+    - name: Ensure download directory exists on windows
       win_file:
         path: "{{ win_download_dir }}"
         state: directory
 
-    - name: download miniconda on windows
+    - name: Download miniconda on windows
       win_get_url:
         url: "{{ win_conda_url }}"
         dest: "{{ win_download_dir }}/{{ win_installer }}"
@@ -121,9 +121,10 @@
       retries: 10
       delay: 2
 
-    - name: install miniconda on windows
+    - name: Install miniconda on windows
       win_shell: '{{ win_download_dir }}\{{ win_installer }} /InstallationType=AllUsers /RegisterPython=1 /AddToPath=1 /S /D={{ miniconda_dir }}'
       args:
         chdir: "{{ win_download_dir }}"
         creates: "{{ miniconda_bindir }}"
   when: ansible_os_family == 'Windows'
+...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,45 +1,46 @@
 ---
 # tasks file for base_conda
-
-- name: set variables
+# Standards: 0.2
+- name: Set variables
   include_vars: "{{ ansible_os_family }}.yml"
   tags: always
 
-- name: check presence of conda
+- name: Check presence of conda
   when: ansible_os_family != 'Windows'
   stat:
     path: "{{ miniconda_bindir }}/conda"
   register: conda_executable
 
-- name: install miniconda
+- name: Install miniconda
   include_tasks: install.yml
   when: ansible_os_family == 'Windows' or not conda_executable.stat.exists
 
 # yamllint disable-rule:line-length
 # https://stackoverflow.com/questions/35605603/using-ansible-set-fact-to-create-a-dictionary-from-register-results
-- name: "create list of dictionaries, conda_files, each with properties 'name' and 'file'"
+- name: "Create list of dictionaries, conda_files, each with properties 'name' and 'file'"
   set_fact:
     conda_files: |
-        {{ conda_files|default([]) + [{'name': lookup('pipe', 'grep ^name: {{ item  }} | cut -d: -f2| tr -d " "' ), 'file': item|basename} ] }}
+        {{ conda_files | default([]) + [{'name': lookup('pipe', 'grep ^name: {{ item }} | cut -d: -f2| tr -d " "' ), 'file': item | basename} ] }}
   with_fileglob: "files/conda-envs/*.y*l"
   tags:
     - list
     - dict
 # yamllint enable-rule:line-length
 
-- name: display list of dictionaries
+- name: Display list of dictionaries
   debug:
     var: conda_files
   tags:
     - list
     - dict
 
-- name: create conda environments on unix
+- name: Create conda environments on unix
   include_tasks: unix.yml
   when: ansible_os_family != 'Windows'
   tags:
     - list
 
-- name: create conda environments on windows
+- name: Create conda environments on windows
   include_tasks: windows.yml
   when: ansible_os_family == 'Windows'
+...

--- a/tasks/unix.yml
+++ b/tasks/unix.yml
@@ -1,6 +1,6 @@
 ---
-
-- name: copy conda-envs
+# Standards: 0.2
+- name: Copy conda-envs
   copy:
     src: "{{ item }}"
     dest: "{{ lin_download_dir }}"
@@ -10,7 +10,7 @@
     - list
 
 - block:
-    - name: check if conda environments are present
+    - name: Check if conda environments are present
       stat:
         path: "{{ miniconda_envsdir }}/{{ item.name }}"
       with_items: "{{ conda_files }}"
@@ -18,7 +18,7 @@
       tags:
         - list
 
-    - name: create conda environments from yml files
+    - name: Create conda environments from yml files
       command: "{{ miniconda_bindir }}/conda env create -f {{ lin_download_dir }}/{{ item.file }}"
       args:
         creates: "{{ miniconda_envsdir }}/{{ item.name }}"
@@ -29,7 +29,7 @@
         - miniconda
         - list
 
-    - name: update conda envs that are present
+    - name: Update conda envs that are present
       command: "{{ miniconda_bindir }}/conda env update --name {{ item.name }} -f {{ lin_download_dir }}/{{ item.file }}"
       changed_when: true
       loop: "{{ conda_files }}"
@@ -40,10 +40,11 @@
         - list
         - notest
 
-- name: cleanup conda
+- name: Cleanup conda
   command: "{{ miniconda_dir }}/bin/conda clean --yes --all"
   register: clean
   changed_when: clean.rc|int == 0
   tags:
     - miniconda
     - notest
+...

--- a/tasks/windows.yml
+++ b/tasks/windows.yml
@@ -1,41 +1,41 @@
 ---
-
-- name: copy conda environment templates
+# Standards: 0.2
+- name: Copy conda environment templates
   win_template:
     dest: 'C:/tmp/'
     src: "{{ item }}"
   with_fileglob: "files/conda-envs/*.yml"
 
-- name: check if conda environments are present
+- name: Check if conda environments are present
   win_stat:
     path: "{{ miniconda_envsdir }}/{{ item.name }}"
   with_items: "{{ conda_files }}"
   register: actual_envs
 
-- name: configure conda environments
+- name: Configure conda environments
   win_shell: |
     cmd.exe {{ miniconda_dir }}/Scripts/activate.bat {{ miniconda_dir }}
-    {{ miniconda_bindir }}/conda env create -f C:/tmp/{{ item.file  }}
+    {{ miniconda_bindir }}/conda env create -f C:/tmp/{{ item.file }}
   args:
     creates: "{{ miniconda_envsdir }}/{{ item.name }}"
   loop: "{{ conda_files }}"
   tags:
     - venv
 
-- name: update conda envs that are present
+- name: Update conda envs that are present
   win_shell: |
     cmd.exe {{ miniconda_dir }}/Scripts/activate.bat {{ miniconda_dir }}
-    {{ miniconda_bindir }}/conda env update --name {{ item.name }} -f C:/tmp/{{ item.file  }}
+    {{ miniconda_bindir }}/conda env update --name {{ item.name }} -f C:/tmp/{{ item.file }}
   changed_when: true
   loop: "{{ conda_files }}"
   loop_control:
     index_var: i
   when: actual_envs.results[i].stat.exists is defined
 
-
-- name: cleanup conda
+- name: Cleanup conda
   win_shell: |
     cmd.exe {{ miniconda_dir }}/Scripts/activate.bat {{ miniconda_dir }}
     {{ miniconda_bindir }}/conda clean --all
   tags:
     - cleanup
+...

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,7 @@
 ---
+# Standards: 0.2
 - hosts: localhost
   remote_user: root
   roles:
     - base_conda
+...

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,0 +1,32 @@
+---
+# Alpine
+# Standards: 0.2
+miniconda_dir: /opt/conda
+miniconda_bindir: /opt/conda/bin
+miniconda_envsdir: /opt/conda/envs
+# main miniconda download server
+miniconda_mirror: "https://repo.continuum.io/miniconda"
+
+# miniconda version
+miniconda_ver: "py39_4.9.2"
+
+# miniconda checksums
+miniconda_checksums:
+  Miniconda3-4.7.12-Linux-x86_64.sh: "md5:0dba759b8ecfc8948f626fa18785e3d8"
+  Miniconda3-4.7.10-Linux-x86_64.sh: "md5:1c945f2b3335c7b2b15130b1b2dc5cf4"
+  Miniconda3-4.6.14-Linux-x86_64.sh: "md5:718259965f234088d785cad1fbd7de03"
+  Miniconda3-4.5.12-Linux-x86_64.sh: "md5:866ae9dff53ad0874e1d1a60b1ad1ef8"
+  Miniconda3-py37_4.9.2-Linux-x86_64.sh: "md5:3143b1116f2d466d9325c206b7de88f7"
+  Miniconda3-py38_4.9.2-Linux-x86_64.sh: "md5:122c8c9beb51e124ab32a0fa6426c656"
+  Miniconda3-py39_4.9.2-Linux-x86_64.sh: "md5:b4e46fcc8029e2cfa731b788f25b1d36"
+# miniconda installer info
+
+# when downloading the miniconda binary it might take a while
+miniconda_timeout_seconds: 600
+
+# yamllint disable-line rule:line-length
+miniconda_name: "Miniconda3-{{ miniconda_ver }}-Linux-x86_64"
+miniconda_installer_sh: "{{ miniconda_name }}.sh"
+miniconda_installer_url: "{{ miniconda_mirror }}/{{ miniconda_installer_sh }}"
+miniconda_checksum: "{{ miniconda_checksums[miniconda_installer_sh] }}"
+...

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,5 +1,7 @@
 ---
 # Mac
+# Standards: 0.2
 miniconda_dir: /usr/local/Caskroom/miniconda
 miniconda_bindir: /usr/local/Caskroom/miniconda/base/condabin
 miniconda_envsdir: /usr/local/Caskroom/miniconda/base/envs
+...

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,7 @@
 ---
 # Debian
+# Standards: 0.2
 miniconda_dir: /opt/conda
 miniconda_bindir: /opt/conda/bin
 miniconda_envsdir: /opt/conda/envs
+...

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,5 +1,7 @@
 ---
 # RedHat
+# Standards: 0.2
 miniconda_dir: /opt/conda
 miniconda_bindir: /opt/conda/bin
 miniconda_envsdir: /opt/conda/envs
+...

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -1,8 +1,10 @@
 ---
 # Windows
+# Standards: 0.2
 win_installer: 'Miniconda3-latest-Windows-x86_64.exe'
 win_conda_url: "https://repo.anaconda.com/miniconda/{{ win_installer }}"
 win_download_dir: 'C:/Downloads/'
 miniconda_bindir: 'C:/ProgramData/Miniconda3/condabin'
 miniconda_dir: 'C:/ProgramData/Miniconda3'
 miniconda_envsdir: 'C:/ProgramData/Miniconda3/envs'
+...

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,4 @@
 ---
+# Standards: 0.2
 lin_download_dir: /var/tmp
+...


### PR DESCRIPTION
ansible-later is a best practice scanner and linting tool. In most cases, if you write Ansible roles in a team, it helps to have a coding or best practice guideline in place. This will make Ansible roles more readable for all maintainers and can reduce the troubleshooting time. While ansible-later aims to be a fast and easy to use linting tool for your Ansible resources, it might not be that feature completed as required in some situations. If you need a more in-depth analysis you can take a look at ansible-lint.

ansible-later does not ensure that your role will work as expected. For deployment tests you can use other tools like molecule.

You can find the full documentation at https://ansible-later.geekdocs.de.