### PR TITLE
FIX redhat conda install if epel enabled

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,6 +45,7 @@
     name: conda
     state: present
   when: ansible_os_family == 'Debian'
+
 - name: Install miniconda package on RedHat
   yum:
     name: conda
@@ -104,7 +105,7 @@
         dest: /etc/profile.d/conda.sh
         state: link
         mode: 0777
-      when: etc_profile_d_conda_sh.stat.exists == False
+      when: not etc_profile_d_conda_sh.stat.exists
 
     - name: Link /etc/profile.d/conda.csh
       file:
@@ -112,7 +113,7 @@
         dest: /etc/profile.d/conda.csh
         state: link
         mode: 0777
-      when: etc_profile_d_conda_csh.stat.exists == False
+      when: not etc_profile_d_conda_csh.stat.exists
   when: ansible_os_family == 'RedHat'
 
 - name: Source conda.sh in /etc/bash.bashrc


### PR DESCRIPTION
# The problem

The epel repo on centos8 has their own conda package that will be installed instead of the one from the conda repo that is added. In principle this is fine, but it installs conda to a different location than the conda repo. This then breaks next the linking steps and any further steps that expect conda to be at `/opt/conda`. So basically if the `base_epel` role is run before this role, stuff breaks.

# The fix

In this PR I have split the logic up a bit so that the install step for RedHat is forced to use the conda repo instead of epel. I also added a check for the linking step on RedHat to make sure we link files that actually exist.