### PR TITLE
FIX converge.yml path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN yum install -y epel-release && \
     yum clean all
 COPY ./files/hosts /etc/ansible/hosts
 ADD . /tmp/ansible/roles/base_conda
-COPY ./molecule/default/converge.yml /tmp/ansible/
+COPY ./molecule/shared/converge.yml /tmp/ansible/
 RUN cd /tmp/ansible && ansible-playbook converge.yml
 ENV PATH /opt/conda/envs/env/bin:$PATH
 ENV LANG C.UTF-8


### PR DESCRIPTION
The current Dockerfile has the old path for converge still in it. It fails to build because of this.

https://github.com/dockpack/base_conda/blob/af0d86832b0ad3c074203268d42c56e2d88dc1af/Dockerfile#L10