### PR TITLE
FIX docker build converge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN yum install -y epel-release && \
 COPY ./files/hosts /etc/ansible/hosts
 ADD . /tmp/ansible/roles/base_conda
 COPY ./molecule/shared/converge.yml /tmp/ansible/
-RUN cd /tmp/ansible && ansible-playbook converge.yml
+RUN cd /tmp/ansible && ansible-playbook -e role_name=base_conda converge.yml
 ENV PATH /opt/conda/envs/env/bin:$PATH
 ENV LANG C.UTF-8


### PR DESCRIPTION
The role_name referenced in converge.yml is empty I guess by default. That skips the role entirely on the docker build. Setting the role_name variable fixes.